### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in each version of the motd-tail cookbook
 
 ## Unreleased
 
+- resolved cookstyle error: resources/motd_tail.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
 ## 5.2.2 - *2021-08-31*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/resources/motd_tail.rb
+++ b/resources/motd_tail.rb
@@ -21,6 +21,7 @@
 #
 
 provides :motd_tail
+unified_mode true
 
 property :path, String, name_property: true
 property :template_source, String


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.25.6 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with resources/motd_tail.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)